### PR TITLE
Add missing packages in shared preferences module

### DIFF
--- a/shared_preferences/go.mod
+++ b/shared_preferences/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/go-flutter-desktop/go-flutter v0.5.0-alpha
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.8.1
 	github.com/syndtr/goleveldb v1.0.0
 )

--- a/shared_preferences/go.sum
+++ b/shared_preferences/go.sum
@@ -2,12 +2,15 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-flutter-desktop/go-flutter v0.5.0-alpha h1:1WaIRPGI2nmO83gYXAaOtPC3gqBns43IW5EnwO5ht/I=
 github.com/go-flutter-desktop/go-flutter v0.5.0-alpha/go.mod h1:bHC0mnEgTyp23W1ymE7PLY1l4jTxGkTBxCnB99dcZFs=
+github.com/go-flutter-desktop/plugins v0.0.0-20190402224255-bc4613525151 h1:SNfruLVG5aLQBB9Qx5iao3rANE29R4QVwWWYbs50iBk=
 github.com/go-gl/glfw v0.0.0-20190217072633-93b30450e032 h1:WUDJN6o1AZlnNR0UZ11zsr0Quh44CV7svcg6VzEsySc=
 github.com/go-gl/glfw v0.0.0-20190217072633-93b30450e032/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db h1:woRePGFeVFfLKN/pOkfl+p/TAqKOfFu+7KPlMVpok/w=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=


### PR DESCRIPTION
Just ran a simple `GO111MODULE=on go mod vendor` command in the `shared_preferences` directory and it populated the `go.mod` and `go.sum` files with these values. Looks like it was probably missing.