### PR TITLE
Add some code reuse for checking programming errors

### DIFF
--- a/Plugin.go
+++ b/Plugin.go
@@ -1,0 +1,11 @@
+package plugins
+
+type Plugin struct {
+	// VendorName must be set to a nonempty value. Use company name or a domain
+	// that you own. Note that the value must be valid as a cross-platform directory name.
+	VendorName string
+	// ApplicationName must be set to a nonempty value. Use the unique name for
+	// this application. Note that the value must be valid as a cross-platform
+	// directory name.
+	ApplicationName string
+}

--- a/Plugin.go
+++ b/Plugin.go
@@ -1,5 +1,7 @@
 package plugins
 
+import "github.com/pkg/errors"
+
 type Plugin struct {
 	// VendorName must be set to a nonempty value. Use company name or a domain
 	// that you own. Note that the value must be valid as a cross-platform directory name.
@@ -8,4 +10,17 @@ type Plugin struct {
 	// this application. Note that the value must be valid as a cross-platform
 	// directory name.
 	ApplicationName string
+}
+
+func (plugin *Plugin) Guard() error {
+	if plugin.VendorName == "" {
+		// returned immediately because this is likely a programming error
+		return errors.New("PathProviderPlugin.VendorName must be set")
+	}
+	if plugin.ApplicationName == "" {
+		// returned immediately because this is likely a programming error
+		return errors.New("PathProviderPlugin.ApplicationName must be set")
+	}
+
+	return nil
 }

--- a/path_provider/plugin.go
+++ b/path_provider/plugin.go
@@ -7,6 +7,7 @@ import (
 
 	flutter "github.com/go-flutter-desktop/go-flutter"
 	"github.com/go-flutter-desktop/go-flutter/plugin"
+	"github.com/go-flutter-desktop/plugins"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 )
@@ -16,13 +17,7 @@ const channelName = "plugins.flutter.io/path_provider"
 // PathProviderPlugin implements flutter.Plugin and handles method calls to
 // the plugins.flutter.io/path_provider channel.
 type PathProviderPlugin struct {
-	// VendorName must be set to a nonempty value. Use company name or a domain
-	// that you own. Note that the value must be valid as a cross-platform directory name.
-	VendorName string
-	// ApplicationName must be set to a nonempty value. Use the unique name for
-	// this application. Note that the value must be valid as a cross-platform
-	// directory name.
-	ApplicationName string
+	plugins.Plugin
 
 	userConfigFolder string
 	codec            plugin.StandardMessageCodec

--- a/path_provider/plugin.go
+++ b/path_provider/plugin.go
@@ -27,13 +27,9 @@ var _ flutter.Plugin = &PathProviderPlugin{} // compile-time type check
 
 // InitPlugin initializes the path provider plugin.
 func (p *PathProviderPlugin) InitPlugin(messenger plugin.BinaryMessenger) error {
-	if p.VendorName == "" {
-		// returned immediately because this is likely a programming error
-		return errors.New("PathProviderPlugin.VendorName must be set")
-	}
-	if p.ApplicationName == "" {
-		// returned immediately because this is likely a programming error
-		return errors.New("PathProviderPlugin.ApplicationName must be set")
+	err := p.Guard()
+	if err != nil {
+		return err
 	}
 
 	switch runtime.GOOS {

--- a/shared_preferences/plugin.go
+++ b/shared_preferences/plugin.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-flutter-desktop/go-flutter/plugin"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
+	"github.com/go-flutter-desktop/plugins"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 )
@@ -19,13 +20,7 @@ const channelName = "plugins.flutter.io/shared_preferences"
 // the plugins.flutter.io/shared_preferences channel. Preferences are stored
 // using leveldb in the users' home directory config location.
 type SharedPreferencesPlugin struct {
-	// VendorName must be set to a nonempty value. Use company name or a domain
-	// that you own. Note that the value must be valid as a cross-platform directory name.
-	VendorName string
-	// ApplicationName must be set to a nonempty value. Use the unique name for
-	// this application. Note that the value must be valid as a cross-platform
-	// directory name.
-	ApplicationName string
+	plugins.Plugin
 
 	userConfigFolder string
 	db               *leveldb.DB

--- a/shared_preferences/plugin.go
+++ b/shared_preferences/plugin.go
@@ -31,13 +31,9 @@ var _ flutter.Plugin = &SharedPreferencesPlugin{} // compile-time type check
 
 // InitPlugin initializes the shared preferences plugin.
 func (p *SharedPreferencesPlugin) InitPlugin(messenger plugin.BinaryMessenger) error {
-	if p.VendorName == "" {
-		// returned immediately because this is likely a programming error
-		return errors.New("SharedPreferencesPlugin.VendorName must be set")
-	}
-	if p.ApplicationName == "" {
-		// returned immediately because this is likely a programming error
-		return errors.New("SharedPreferencesPlugin.ApplicationName must be set")
+	err := p.Guard()
+	if err != nil {
+		return err
 	}
 
 	switch runtime.GOOS {
@@ -63,7 +59,6 @@ func (p *SharedPreferencesPlugin) InitPlugin(messenger plugin.BinaryMessenger) e
 	}
 
 	// TODO: move into a getDB call which initializes on first use, lower startup latency.
-	var err error
 	p.db, err = leveldb.OpenFile(filepath.Join(p.userConfigFolder, p.VendorName, p.ApplicationName, "shared_preferences.leveldb"), nil)
 	if err != nil {
 		// TODO: when moved into getDB: error shouldn't kill the plugin and thereby the whole app,


### PR DESCRIPTION
- Extracts `VendorName` and `ApplicationName` into a reusable struct
- Adds a `Guard` function to check for the existence of the `VendorName` and `ApplicationName` fields rather than copy and pasting them each time.
- May have unintended consquences since all plugins will now have a dependency on its root directory