### PR TITLE
Add 'warble' plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Please report issues at the [go-flutter issue tracker](https://github.com/go-flu
 - [open_file](https://github.com/jld3103/go-flutter-open_file) - Flutter plugin for opening a file or URI using the default application on the platform. ([pub.dev](https://pub.dev/packages/open_file))
 - [firebase_remote_config](https://github.com/jWinterDay/firebase_remote_config) - Flutter plugin for reading firebase remote config ([pub.dev](https://pub.dev/packages/firebase_remote_config))
 - [flutter_systray](https://github.com/JanezStupar/flutter_systray) - Flutter plugin for systray menu support.
+- [warble](https://github.com/jslater89/warble) - Play audio from assets, files, or in-memory buffers. ([pub.dev](https://pub.dev/packages/warble))
 
 If you have implemented a plugin that you would like to add to this repository,
 feel free to open a PR.


### PR DESCRIPTION
I'm working on an audio-player plugin based on the [beep](https://pkg.go.dev/github.com/faiface/beep#section-documentation) library for Go. Very basic at present, and only tested on Linux, but supports playing sound from assets, files, and in-memory buffers at present, and has some minimal support for pan and gain.